### PR TITLE
add Helmet/SEO for title + metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@types/node": "^17.0.14",
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",
+        "@types/react-helmet": "^6.1.5",
         "@types/use-persisted-state": "^0.3.1",
         "cypress": "^9.5.1",
         "gh-pages": "^3.2.3",
@@ -4472,6 +4473,15 @@
       "version": "17.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-helmet": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.5.tgz",
+      "integrity": "sha512-/ICuy7OHZxR0YCAZLNg9r7I9aijWUWvxaPR6uTuyxe8tAj5RL4Sw1+R6NhXUtOsarkGYPmaHdBDvuXh2DIN/uA==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -26027,6 +26037,15 @@
       "version": "17.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
       "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-helmet": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-helmet/-/react-helmet-6.1.5.tgz",
+      "integrity": "sha512-/ICuy7OHZxR0YCAZLNg9r7I9aijWUWvxaPR6uTuyxe8tAj5RL4Sw1+R6NhXUtOsarkGYPmaHdBDvuXh2DIN/uA==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/node": "^17.0.14",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
+    "@types/react-helmet": "^6.1.5",
     "@types/use-persisted-state": "^0.3.1",
     "cypress": "^9.5.1",
     "gh-pages": "^3.2.3",

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+const SEO = () => (
+  <Helmet>
+    <meta charSet="utf-8" />
+    <title>Degen Community</title>
+    <link rel="canonical" href="https://degentoken.xyz" />
+  </Helmet>
+)
+
+export default SEO;

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -19,6 +19,7 @@ import '@fontsource/roboto-mono';
 
 import useWalletAccount from './utils/persistAccount';
 import AccountInfoPopover from "./components/accountInfoPopover";
+import SEO from "./components/seo";
 
 if (typeof window !== `undefined`) {
   (window as any).Buffer = buffer.Buffer;
@@ -99,24 +100,26 @@ const Layout = ({children}:LayoutProps) => {
   }
 
   return (
-    
-    <ChakraProvider theme={theme}>
-      <WalletConnectModal isOpen={isOpen} onClose={onClose}>
-        <Button width={'100%'} marginBottom={'10px'} onClickHandler={handleMyAlgoConnect} text={"Connect MyAlgo"} dataTest={'myAlgoConnectButton'} />
-        <Button width={'100%'} marginBottom={'10px'} onClickHandler={handleWalletConnect} text={"Wallet Connect"} dataTest={'walletConnectButton'} />
-      </WalletConnectModal>
-      <Navbar>
-      <ColorModeToggle/>
-      {account?.connected?
-        <AccountInfoPopover address={account.address} disconnect={handleDisconnect} />
-        :
-        <Button width={'100%'} marginBottom={'10px'} onClickHandler={onOpen} text={"Connect Wallet"} dataTest={'connectWalletButton'}/>
-      } 
-      </Navbar>
-      <Container maxW={'7xl'}>
-        {children}
-      </Container>
-    </ChakraProvider>
+    <>
+      <SEO />
+      <ChakraProvider theme={theme}>
+        <WalletConnectModal isOpen={isOpen} onClose={onClose}>
+          <Button width={'100%'} marginBottom={'10px'} onClickHandler={handleMyAlgoConnect} text={"Connect MyAlgo"} dataTest={'myAlgoConnectButton'} />
+          <Button width={'100%'} marginBottom={'10px'} onClickHandler={handleWalletConnect} text={"Wallet Connect"} dataTest={'walletConnectButton'} />
+        </WalletConnectModal>
+        <Navbar>
+        <ColorModeToggle/>
+        {account?.connected?
+          <AccountInfoPopover address={account.address} disconnect={handleDisconnect} />
+          :
+          <Button width={'100%'} marginBottom={'10px'} onClickHandler={onOpen} text={"Connect Wallet"} dataTest={'connectWalletButton'}/>
+        } 
+        </Navbar>
+        <Container maxW={'7xl'}>
+          {children}
+        </Container>
+      </ChakraProvider>
+    </>
   )
 }
 


### PR DESCRIPTION
The pull request adds [Helmet](https://www.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/), a gatsby library to simplify html metadata (title and other metadata). I've added this to it's own component called SEO, I think in the future we could pass in a prop to this component to pass in title and SEO information for subpages.